### PR TITLE
Add inline handlers for pending routes

### DIFF
--- a/src/routes/donationRoutes.ts
+++ b/src/routes/donationRoutes.ts
@@ -5,6 +5,7 @@ import {
   getDonationApprovalRequestsByUser,
   updateDonationApprovalRequest,
 } from '../controllers/donationController';
+import { db } from '../utils/db';
 
 const router = Router();
 
@@ -12,6 +13,19 @@ router.post('/', createDonationApprovalRequest);
 router.put('/:requestId', updateDonationApprovalRequest);
 router.get('/user', getDonationApprovalRequestsByUser);
 router.get('/request/:requestId', getdonationApprovalRequestsByRequest);
+
+router.delete('/:id', async (req, res) => {
+  try {
+    const { id } = req.params;
+    await db.collection('donationsRequests').doc(id).delete();
+    res
+      .status(200)
+      .json({ message: 'Donation approval request deleted successfully' });
+  } catch (error) {
+    console.error('Error deleting donation approval request:', error);
+    res.status(500).json({ message: 'Internal server error' });
+  }
+});
 
 
 export default router;

--- a/src/routes/userRoutes.ts
+++ b/src/routes/userRoutes.ts
@@ -1,24 +1,87 @@
 import { Router } from 'express';
-import { createUser, getUsers, getUserInfo,updateUserFile, editUserInfo, deleteUserFilesInfo} from '../controllers/userController';
+import { createUser, getUsers } from '../controllers/userController';
+import { db } from '../utils/db';
 
 const router = Router();
 
-router.post('/users', createUser);
-/**
- * @openapi
- * /api/users:
- *   get:
- *     summary: Get all users
- *     responses:
- *       200:
- *         description: A list of users
- */
-router.get('/', getUsers);
-router.get('/:id', getUserInfo);
 router.post('/', createUser);
-/* router.get('/profile', getCurrentUserInfo); // Assuming this function is defined in userController
- */router.put('/:userId', editUserInfo);
-router.post('/documents/', updateUserFile);
-router.delete('/documents/', deleteUserFilesInfo);
+router.get('/', getUsers);
+
+router.get('/:id', async (req, res) => {
+  try {
+    const userId = Number(req.params.id);
+    const snapshot = await db
+      .collection('users')
+      .where('id', '==', userId)
+      .get();
+    if (snapshot.empty) {
+      return res.status(404).send('User not found');
+    }
+    res.status(200).send(snapshot.docs[0].data());
+  } catch (error) {
+    console.error('Error fetching user:', error);
+    res.status(500).send('Internal Server Error');
+  }
+});
+
+router.put('/:userId', async (req, res) => {
+  try {
+    const userId = Number(req.params.userId);
+    const snapshot = await db
+      .collection('users')
+      .where('id', '==', userId)
+      .get();
+    if (snapshot.empty) {
+      return res.status(404).send('User not found');
+    }
+    await snapshot.docs[0].ref.update(req.body);
+    res.status(200).send('User updated successfully');
+  } catch (error) {
+    console.error('Error updating user:', error);
+    res.status(500).send('Internal Server Error');
+  }
+});
+
+router.post('/documents', async (req, res) => {
+  try {
+    const { userId, ...fileData } = req.body;
+    if (!userId) {
+      return res.status(400).send('Missing userId');
+    }
+    const snapshot = await db
+      .collection('users')
+      .where('id', '==', Number(userId))
+      .get();
+    if (snapshot.empty) {
+      return res.status(404).send('User not found');
+    }
+    await snapshot.docs[0].ref.update(fileData);
+    res.status(200).send('File info updated');
+  } catch (error) {
+    console.error('Error updating file info:', error);
+    res.status(500).send('Internal Server Error');
+  }
+});
+
+router.delete('/documents', async (req, res) => {
+  try {
+    const { userId } = req.body;
+    if (!userId) {
+      return res.status(400).send('Missing userId');
+    }
+    const snapshot = await db
+      .collection('users')
+      .where('id', '==', Number(userId))
+      .get();
+    if (snapshot.empty) {
+      return res.status(404).send('User not found');
+    }
+    await snapshot.docs[0].ref.update({ idFile: '', profilePicture: '' });
+    res.status(200).send('File info removed');
+  } catch (error) {
+    console.error('Error deleting file info:', error);
+    res.status(500).send('Internal Server Error');
+  }
+});
 
 export default router;


### PR DESCRIPTION
## Summary
- add deletion endpoint for donation approval requests
- inline user routes for user retrieval, updates, and document management

## Testing
- `npm test` *(fails: No tests found)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892f5607be08326b251a067c4552aac